### PR TITLE
Lower MSRV by restoring the old non-const generics code on < 1.54

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ libcore_neon = []
 paste = "^0.1.3"
 arrayvec = { version = "^0.5", default-features = false }
 
+[build-dependencies]
+rustc_version = "0.2"
+
 [target.'cfg(target_arch = "x86_64")'.dependencies.sleef-sys]
 version = "0.1.2"
 optional = true

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,14 @@
+use rustc_version::{version, Version};
+
 fn main() {
     println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
     let target = std::env::var("TARGET")
         .expect("TARGET environment variable not defined");
     if target.contains("neon") {
         println!("cargo:rustc-cfg=libcore_neon");
+    }
+    let ver = version().unwrap();
+    if ver >= Version::parse("1.54.0").unwrap() {
+        println!("cargo:rustc-cfg=use_const_generics");
     }
 }

--- a/src/api/shuffle.rs
+++ b/src/api/shuffle.rs
@@ -74,6 +74,7 @@
 /// // At most 2 * the number of lanes in the input vector.
 /// # }
 /// ```
+#[cfg(use_const_generics)]
 #[macro_export]
 macro_rules! shuffle {
     ($vec0:expr, $vec1:expr, [$l0:expr, $l1:expr]) => {{
@@ -177,6 +178,121 @@ macro_rules! shuffle {
             ]}, _, _>(
                 $vec0.0,
                 $vec1.0,
+            ))
+        }
+     }};
+    ($vec:expr, [$($l:expr),*]) => {
+        match $vec {
+            v => shuffle!(v, v, [$($l),*])
+        }
+    };
+}
+#[cfg(not(use_const_generics))]
+#[macro_export]
+macro_rules! shuffle {
+    ($vec0:expr, $vec1:expr, [$l0:expr, $l1:expr]) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::Simd($crate::__shuffle_vector2(
+                $vec0.0,
+                $vec1.0,
+                [$l0, $l1],
+            ))
+        }
+    }};
+    ($vec0:expr, $vec1:expr, [$l0:expr, $l1:expr, $l2:expr, $l3:expr]) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::Simd($crate::__shuffle_vector4(
+                $vec0.0,
+                $vec1.0,
+                [$l0, $l1, $l2, $l3],
+            ))
+        }
+    }};
+    ($vec0:expr, $vec1:expr,
+     [$l0:expr, $l1:expr, $l2:expr, $l3:expr,
+      $l4:expr, $l5:expr, $l6:expr, $l7:expr]) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::Simd($crate::__shuffle_vector8(
+                $vec0.0,
+                $vec1.0,
+                [$l0, $l1, $l2, $l3, $l4, $l5, $l6, $l7],
+            ))
+        }
+    }};
+    ($vec0:expr, $vec1:expr,
+     [$l0:expr, $l1:expr, $l2:expr, $l3:expr,
+      $l4:expr, $l5:expr, $l6:expr, $l7:expr,
+      $l8:expr, $l9:expr, $l10:expr, $l11:expr,
+      $l12:expr, $l13:expr, $l14:expr, $l15:expr]) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::Simd($crate::__shuffle_vector16(
+                $vec0.0,
+                $vec1.0,
+                [
+                    $l0, $l1, $l2, $l3, $l4, $l5, $l6, $l7, $l8, $l9, $l10,
+                    $l11, $l12, $l13, $l14, $l15,
+                ],
+            ))
+        }
+    }};
+    ($vec0:expr, $vec1:expr,
+     [$l0:expr, $l1:expr, $l2:expr, $l3:expr,
+      $l4:expr, $l5:expr, $l6:expr, $l7:expr,
+      $l8:expr, $l9:expr, $l10:expr, $l11:expr,
+      $l12:expr, $l13:expr, $l14:expr, $l15:expr,
+      $l16:expr, $l17:expr, $l18:expr, $l19:expr,
+      $l20:expr, $l21:expr, $l22:expr, $l23:expr,
+      $l24:expr, $l25:expr, $l26:expr, $l27:expr,
+      $l28:expr, $l29:expr, $l30:expr, $l31:expr]) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::Simd($crate::__shuffle_vector32(
+                $vec0.0,
+                $vec1.0,
+                [
+                    $l0, $l1, $l2, $l3, $l4, $l5, $l6, $l7, $l8, $l9, $l10,
+                    $l11, $l12, $l13, $l14, $l15, $l16, $l17, $l18, $l19,
+                    $l20, $l21, $l22, $l23, $l24, $l25, $l26, $l27, $l28,
+                    $l29, $l30, $l31,
+                ],
+            ))
+        }
+    }};
+    ($vec0:expr, $vec1:expr,
+     [$l0:expr, $l1:expr, $l2:expr, $l3:expr,
+      $l4:expr, $l5:expr, $l6:expr, $l7:expr,
+      $l8:expr, $l9:expr, $l10:expr, $l11:expr,
+      $l12:expr, $l13:expr, $l14:expr, $l15:expr,
+      $l16:expr, $l17:expr, $l18:expr, $l19:expr,
+      $l20:expr, $l21:expr, $l22:expr, $l23:expr,
+      $l24:expr, $l25:expr, $l26:expr, $l27:expr,
+      $l28:expr, $l29:expr, $l30:expr, $l31:expr,
+      $l32:expr, $l33:expr, $l34:expr, $l35:expr,
+      $l36:expr, $l37:expr, $l38:expr, $l39:expr,
+      $l40:expr, $l41:expr, $l42:expr, $l43:expr,
+      $l44:expr, $l45:expr, $l46:expr, $l47:expr,
+      $l48:expr, $l49:expr, $l50:expr, $l51:expr,
+      $l52:expr, $l53:expr, $l54:expr, $l55:expr,
+      $l56:expr, $l57:expr, $l58:expr, $l59:expr,
+      $l60:expr, $l61:expr, $l62:expr, $l63:expr]) => {{
+        #[allow(unused_unsafe)]
+        unsafe {
+            $crate::Simd($crate::__shuffle_vector64(
+                $vec0.0,
+                $vec1.0,
+                [
+                    $l0, $l1, $l2, $l3, $l4, $l5, $l6, $l7, $l8, $l9, $l10,
+                    $l11, $l12, $l13, $l14, $l15, $l16, $l17, $l18, $l19,
+                    $l20, $l21, $l22, $l23, $l24, $l25, $l26, $l27, $l28,
+                    $l29, $l30, $l31, $l32, $l33, $l34, $l35, $l36, $l37,
+                    $l38, $l39, $l40, $l41, $l42, $l43, $l44, $l45, $l46,
+                    $l47, $l48, $l49, $l50, $l51, $l52, $l53, $l54, $l55,
+                    $l56, $l57, $l58, $l59, $l60, $l61, $l62, $l63,
+                ],
             ))
         }
      }};

--- a/src/codegen/llvm.rs
+++ b/src/codegen/llvm.rs
@@ -6,6 +6,7 @@ use crate::sealed::Shuffle;
 use crate::sealed::Simd;
 
 // Shuffle intrinsics: expanded in users' crates, therefore public.
+#[cfg(use_const_generics)]
 extern "platform-intrinsic" {
     pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U;
     pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U;
@@ -15,6 +16,7 @@ extern "platform-intrinsic" {
     pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U;
 }
 
+#[cfg(use_const_generics)]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn __shuffle_vector2<const IDX: [u32; 2], T, U>(x: T, y: T) -> U
@@ -25,6 +27,7 @@ where
     simd_shuffle2(x, y, IDX)
 }
 
+#[cfg(use_const_generics)]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn __shuffle_vector4<const IDX: [u32; 4], T, U>(x: T, y: T) -> U
@@ -35,6 +38,7 @@ where
     simd_shuffle4(x, y, IDX)
 }
 
+#[cfg(use_const_generics)]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn __shuffle_vector8<const IDX: [u32; 8], T, U>(x: T, y: T) -> U
@@ -45,6 +49,7 @@ where
     simd_shuffle8(x, y, IDX)
 }
 
+#[cfg(use_const_generics)]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn __shuffle_vector16<const IDX: [u32; 16], T, U>(x: T, y: T) -> U
@@ -55,6 +60,7 @@ where
     simd_shuffle16(x, y, IDX)
 }
 
+#[cfg(use_const_generics)]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn __shuffle_vector32<const IDX: [u32; 32], T, U>(x: T, y: T) -> U
@@ -65,6 +71,7 @@ where
     simd_shuffle32(x, y, IDX)
 }
 
+#[cfg(use_const_generics)]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn __shuffle_vector64<const IDX: [u32; 64], T, U>(x: T, y: T) -> U
@@ -74,6 +81,61 @@ where
 {
     simd_shuffle64(x, y, IDX)
 }
+
+#[cfg(not(use_const_generics))]
+extern "platform-intrinsic" {
+    // FIXME: Passing this intrinsics an `idx` array with an index that is
+    // out-of-bounds will produce a monomorphization-time error.
+    // https://github.com/rust-lang-nursery/packed_simd/issues/21
+    #[rustc_args_required_const(2)]
+    pub fn simd_shuffle2<T, U>(x: T, y: T, idx: [u32; 2]) -> U
+    where
+        T: Simd,
+        <T as Simd>::Element: Shuffle<[u32; 2], Output = U>;
+
+    #[rustc_args_required_const(2)]
+    pub fn simd_shuffle4<T, U>(x: T, y: T, idx: [u32; 4]) -> U
+    where
+        T: Simd,
+        <T as Simd>::Element: Shuffle<[u32; 4], Output = U>;
+
+    #[rustc_args_required_const(2)]
+    pub fn simd_shuffle8<T, U>(x: T, y: T, idx: [u32; 8]) -> U
+    where
+        T: Simd,
+        <T as Simd>::Element: Shuffle<[u32; 8], Output = U>;
+
+    #[rustc_args_required_const(2)]
+    pub fn simd_shuffle16<T, U>(x: T, y: T, idx: [u32; 16]) -> U
+    where
+        T: Simd,
+        <T as Simd>::Element: Shuffle<[u32; 16], Output = U>;
+
+    #[rustc_args_required_const(2)]
+    pub fn simd_shuffle32<T, U>(x: T, y: T, idx: [u32; 32]) -> U
+    where
+        T: Simd,
+        <T as Simd>::Element: Shuffle<[u32; 32], Output = U>;
+
+    #[rustc_args_required_const(2)]
+    pub fn simd_shuffle64<T, U>(x: T, y: T, idx: [u32; 64]) -> U
+    where
+        T: Simd,
+        <T as Simd>::Element: Shuffle<[u32; 64], Output = U>;
+}
+
+#[cfg(not(use_const_generics))]
+pub use self::simd_shuffle16 as __shuffle_vector16;
+#[cfg(not(use_const_generics))]
+pub use self::simd_shuffle2 as __shuffle_vector2;
+#[cfg(not(use_const_generics))]
+pub use self::simd_shuffle32 as __shuffle_vector32;
+#[cfg(not(use_const_generics))]
+pub use self::simd_shuffle4 as __shuffle_vector4;
+#[cfg(not(use_const_generics))]
+pub use self::simd_shuffle64 as __shuffle_vector64;
+#[cfg(not(use_const_generics))]
+pub use self::simd_shuffle8 as __shuffle_vector8;
 
 extern "platform-intrinsic" {
     crate fn simd_eq<T, U>(x: T, y: T) -> U;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,8 +199,9 @@
 //!   Numeric casts are not very "precise": sometimes lossy, sometimes value
 //!   preserving, etc.
 
+#![cfg_attr(use_const_generics, feature(const_generics))]
+#![cfg_attr(use_const_generics, allow(incomplete_features, clippy::from_over_into))]
 #![feature(
-    const_generics,
     repr_simd,
     rustc_attrs,
     platform_intrinsics,
@@ -217,7 +218,6 @@
         // FIXME: these types are unsound in C FFI already
         // See https://github.com/rust-lang/rust/issues/53346
         improper_ctypes_definitions,
-        incomplete_features,
         clippy::cast_possible_truncation,
         clippy::cast_lossless,
         clippy::cast_possible_wrap,
@@ -228,7 +228,6 @@
         // See https://github.com/rust-lang/rust-clippy/issues/3410
         clippy::use_self,
         clippy::wrong_self_convention,
-        clippy::from_over_into,
 )]
 #![cfg_attr(test, feature(hashmap_internals))]
 #![deny(rust_2018_idioms, clippy::missing_inline_in_public_items)]


### PR DESCRIPTION
Use rustc_version 0.2 rather than the latest version because that's
what's already vendored in mozilla-central.