### PR TITLE
Update to 0.3.7 and remove some now unnecessary divergence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packed_simd_2"
-version = "0.3.6"
+version = "0.3.7"
 description = "Portable Packed SIMD vectors"
 documentation = "https://docs.rs/crate/packed_simd/"
 homepage = "https://github.com/rust-lang/packed_simd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,6 @@ default = []
 into_bits = []
 libcore_neon = []
 
-[build-dependencies]
-rustc_version = "0.2"
-
 [dev-dependencies]
 paste = "^0.1.3"
 arrayvec = { version = "^0.5", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -1,32 +1,6 @@
-use rustc_version::{version_meta, Channel, Version};
-
 fn main() {
     let target = std::env::var("TARGET").expect("TARGET environment variable not defined");
     if target.contains("neon") {
         println!("cargo:rustc-cfg=libcore_neon");
-    }
-    let ver_meta = version_meta().unwrap();
-    let old_const_generics =
-        if ver_meta.semver < Version::parse("1.56.0-alpha").unwrap() {
-            true
-        } else if ver_meta.semver >= Version::parse("1.57.0-alpha").unwrap() {
-            false
-        } else {
-            match ver_meta.channel {
-                Channel::Stable | Channel::Beta => false,
-                Channel::Nightly | Channel::Dev
-                    if ver_meta
-                        .commit_date
-                        .as_deref()
-                        .map(|d| d < "2021-08-31")
-                        .unwrap_or(false) =>
-                {
-                    true
-                }
-                _ => false,
-            }
-        };
-    if old_const_generics {
-        println!("cargo:rustc-cfg=const_generics");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,6 @@
     stmt_expr_attributes,
     crate_visibility_modifier,
     custom_inner_attributes,
-    llvm_asm
 )]
 #![allow(non_camel_case_types, non_snake_case,
         // FIXME: these types are unsound in C FFI already

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,8 @@
 //! options during builds. For more information, see the [Performance
 //! guide](https://rust-lang-nursery.github.io/packed_simd/perf-guide/)
 
-#![cfg_attr(const_generics, feature(const_generics))]
-#![cfg_attr(not(const_generics), feature(adt_const_params))]
 #![feature(
+    adt_const_params,
     repr_simd,
     rustc_attrs,
     platform_intrinsics,

--- a/verify/verify/src/lib.rs
+++ b/verify/verify/src/lib.rs
@@ -2,7 +2,7 @@
 // See https://github.com/rust-lang/rust/issues/53346
 #![allow(improper_ctypes_definitions)]
 #![deny(rust_2018_idioms)]
-#![cfg_attr(test, feature(avx512_target_feature, abi_vectorcall, llvm_asm))]
+#![cfg_attr(test, feature(avx512_target_feature, abi_vectorcall))]
 
 #[cfg(test)]
 mod api;


### PR DESCRIPTION
As Firefox now requires rustc 1.59.0, we don't need the compatibility stuff anymore. That leaves us with only two differences with upstream: the removal of rust-toolchain (which doesn't matter for vendoring in Firefox) and the removal of the libm dependency.